### PR TITLE
🐛 fix: ensure request body properties are defined

### DIFF
--- a/src/openapi/index.ts
+++ b/src/openapi/index.ts
@@ -30,7 +30,7 @@ export class OpenAPIConvertor {
 
           const parameters = this.mergeSchemas(...Object.values(parametersSchema));
 
-          if (requestBodySchema && Object.keys(requestBodySchema.properties).length > 0) {
+          if (requestBodySchema && requestBodySchema.properties && Object.keys(requestBodySchema.properties).length > 0) {
             parameters.properties[OPENAPI_REQUEST_BODY_KEY] = requestBodySchema;
             parameters.required?.push('_requestBody');
           }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Sometimes when parsing more complex openapi schemas, this crash can happen:
```
Error processing request: TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at OpenAPIConvertor.convertOpenAPIToPluginSchema (/Users/lucasnegritto/projects/dynama-builder/tools-api/node_modules/@lobehub/chat-plugin-sdk/lib/openapi/index.js:55:45)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async convertManifest (/Users/lucasnegritto/projects/dynama-builder/tools-api/index.js:43:26)
    at async /Users/lucasnegritto/projects/dynama-builder/tools-api/index.js:74:54
```

By ensuring the request body properties are defined, we prevent trying to convert an undefined or null object to keys, avoiding the TypeError.
